### PR TITLE
use offsetof to calculate the pointer to the struct

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -33,6 +33,7 @@
 
 #define SDS_MAX_PREALLOC (1024*1024)
 
+#include <stddef.h>
 #include <sys/types.h>
 #include <stdarg.h>
 
@@ -44,13 +45,23 @@ struct sdshdr {
     char buf[];
 };
 
+static inline void *sds_start(const sds s)
+{
+#ifdef USE_OFFSETOFF
+    static int sds_buf_offset = (int)offsetof(struct sdshdr, buf);
+    return s - sds_buf_offset;
+#else
+    return s-sizeof(struct sdshdr);
+#endif
+}
+
 static inline size_t sdslen(const sds s) {
-    struct sdshdr *sh = (void*)(s-sizeof *sh);
+    struct sdshdr *sh = sds_start(s);
     return sh->len;
 }
 
 static inline size_t sdsavail(const sds s) {
-    struct sdshdr *sh = (void*)(s-sizeof *sh);
+    struct sdshdr *sh = sds_start(s);
     return sh->free;
 }
 


### PR DESCRIPTION
If the compiler inserts padding before the "buf" member of struct sds,
then "offsetof" is the correct way to calculate the beginning of the
struct.  The C standard specifies/specified that any padding be inserted
_after_ the flexible array member, but most compilers don't do that.
There is a DR here: http://std.dkuug.dk/JTC1/SC22/WG14/www/docs/n983.htm

Also see http://std.dkuug.dk/JTC1/SC22/WG14/www/docs/n987.htm

Note that this commit doesn't change the current method of calculating the start of the buffer, but it adds an easy way to switch between the current method and the proposed method.

All tests pass.
