### PR TITLE
Correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,4 +872,4 @@ it without issues.
 Credits and license
 ===
 
-SDS was created by Salvatore Sanfilippo and is released under the BDS two clause license. See the LICENSE file in this source distribution for more information.
+SDS was created by Salvatore Sanfilippo and is released under the BSD two clause license. See the LICENSE file in this source distribution for more information.


### PR DESCRIPTION
BSD license was named BDS.
