### PR TITLE
Allow sdsrange to make a string with length 0.

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -395,7 +395,7 @@ void sdsrange(sds s, int start, int end) {
     }
     if (end < 0) {
         end = len+end;
-        if (end < 0) end = 0;
+        if (end < -1) end = -1;
     }
     newlen = (start > end) ? 0 : (end-start)+1;
     if (newlen != 0) {


### PR DESCRIPTION
sdsrange(str, 0, -2) should result in an empty string.

For example

sds str = sdsnew("hello");
while (sdslen(str) > 0)
    str = sdsrange(str, 0, -2);

Would result in an inifinty loop before but will work as expected after
this patch.
