### PR TITLE
Hide `sdshdr' structure with flexible array member.

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -36,6 +36,12 @@
 
 #include "sds.h"
 
+struct sdshdr {
+    int len;
+    int free;
+    char buf[];
+};
+
 /* Create a new sds string with the content specified by the 'init' pointer
  * and 'initlen'.
  * If NULL is used for 'init' the string is initialized with zero bytes.

--- a/sds.h
+++ b/sds.h
@@ -35,22 +35,31 @@
 
 #include <sys/types.h>
 #include <stdarg.h>
+#include <stddef.h>
 
 typedef char *sds;
 
-struct sdshdr {
+/* This is a dummy structure to compute `len' and `free' offsets, not to be
+ * used by applications.  The original structure, `sdshdr' (defined in
+ * `sds.c') uses a flexible array member for `buf', making it invalid for
+ * C++.  Assuming that both C and C++ code gets compiled by the same compiler
+ * suite, the replacement below should give the same offsets so that `sdslen'
+ * and `sdavail' can stay as inline definitions. */
+struct sdshdr_h_ {
     int len;
     int free;
-    char buf[];
+    char buf[1000];
 };
 
 static inline size_t sdslen(const sds s) {
-    struct sdshdr *sh = (void*)(s-sizeof *sh);
+    struct sdshdr_h_ *sh = (struct sdshdr_h_*)
+                             (s-(int)offsetof(struct sdshdr_h_, buf));
     return sh->len;
 }
 
 static inline size_t sdsavail(const sds s) {
-    struct sdshdr *sh = (void*)(s-sizeof *sh);
+    struct sdshdr_h_ *sh = (struct sdshdr_h_*)
+                             (s-(int)offsetof(struct sdshdr_h_, buf));
     return sh->free;
 }
 


### PR DESCRIPTION
The idea is that `sds.c` gets compiled with a C99 compliant compiler, and a
C++ program then uses it.  To do so, it needs access to `sds.h`, and this
commit makes the header file valid C++ code.

Note that this patch omits the `extern "C"` guard necessary for C++, since
it is already available in other push requests (https://github.com/antirez/sds/pull/31 and https://github.com/antirez/sds/pull/32).
