### PR TITLE
Make all API functions accept NULL as input.

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -85,6 +85,7 @@ sds sdsdup(const sds s) {
 /* Free an sds string. No operation is performed if 's' is NULL. */
 void sdsfree(sds s) {
     if (s == NULL) return;
+
     free(s-sizeof(struct sdshdr));
 }
 
@@ -103,6 +104,8 @@ void sdsfree(sds s) {
  * the output will be "6" as the string was modified but the logical length
  * remains 6 bytes. */
 void sdsupdatelen(sds s) {
+    if (s == NULL) return;
+
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
     int reallen = strlen(s);
     sh->free += (sh->len-reallen);
@@ -114,6 +117,8 @@ void sdsupdatelen(sds s) {
  * so that next append operations will not require allocations up to the
  * number of bytes previously available. */
 void sdsclear(sds s) {
+    if (s == NULL) return;
+
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
     sh->free += sh->len;
     sh->len = 0;
@@ -127,6 +132,8 @@ void sdsclear(sds s) {
  * Note: this does not change the *length* of the sds string as returned
  * by sdslen(), but only the free buffer space we have. */
 sds sdsMakeRoomFor(sds s, size_t addlen) {
+    if (s == NULL) return NULL;
+
     struct sdshdr *sh, *newsh;
     size_t free = sdsavail(s);
     size_t len, newlen;
@@ -153,6 +160,8 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
  * After the call, the passed sds string is no longer valid and all the
  * references must be substituted with the new pointer returned by the call. */
 sds sdsRemoveFreeSpace(sds s) {
+    if (s == NULL) return NULL;
+
     struct sdshdr *sh;
 
     sh = (void*) (s-sizeof *sh);;
@@ -169,6 +178,8 @@ sds sdsRemoveFreeSpace(sds s) {
  * 4) The implicit null term.
  */
 size_t sdsAllocSize(sds s) {
+    if (s == NULL) return 0;
+
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
 
     return sizeof(*sh)+sh->len+sh->free+1;
@@ -198,6 +209,8 @@ size_t sdsAllocSize(sds s) {
  * sdsIncrLen(s, nread);
  */
 void sdsIncrLen(sds s, int incr) {
+    if (s == NULL) return;
+
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
 
     assert(sh->free >= incr);
@@ -213,6 +226,8 @@ void sdsIncrLen(sds s, int incr) {
  * if the specified length is smaller than the current length, no operation
  * is performed. */
 sds sdsgrowzero(sds s, size_t len) {
+    if (s == NULL) return NULL;
+
     struct sdshdr *sh = (void*) (s-sizeof *sh);
     size_t totlen, curlen = sh->len;
 
@@ -267,6 +282,8 @@ sds sdscatsds(sds s, const sds t) {
 /* Destructively modify the sds string 's' to hold the specified binary
  * safe string pointed by 't' of length 'len' bytes. */
 sds sdscpylen(sds s, const char *t, size_t len) {
+    if (s == NULL) return NULL;
+
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
     size_t totlen = sh->free+sh->len;
 
@@ -353,6 +370,8 @@ sds sdscatprintf(sds s, const char *fmt, ...) {
  * Output will be just "Hello World".
  */
 void sdstrim(sds s, const char *cset) {
+    if (s == NULL) return;
+
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
     char *start, *end, *sp, *ep;
     size_t len;

--- a/sds.h
+++ b/sds.h
@@ -45,11 +45,15 @@ struct sdshdr {
 };
 
 static inline size_t sdslen(const sds s) {
+    if (s == NULL) return 0;
+
     struct sdshdr *sh = (void*)(s-sizeof *sh);
     return sh->len;
 }
 
 static inline size_t sdsavail(const sds s) {
+    if (s == NULL) return 0;
+
     struct sdshdr *sh = (void*)(s-sizeof *sh);
     return sh->free;
 }


### PR DESCRIPTION
Doing so enormously simplifies error handling; you no longer have to check
for memory allocation errors in a chain of sds function calls, only after
the last call.
