### PR TITLE
Portable INLINE macro to support Visual Studio (2013+)

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -44,12 +44,18 @@ struct sdshdr {
     char buf[];
 };
 
-static inline size_t sdslen(const sds s) {
+#ifdef _MSC_VER
+    #define INLINE __forceinline /* use __forceinline (VC++ specific) */
+#else
+    #define INLINE inline        /* use standard inline */
+#endif
+
+static INLINE size_t sdslen(const sds s) {
     struct sdshdr *sh = (void*)(s-sizeof *sh);
     return sh->len;
 }
 
-static inline size_t sdsavail(const sds s) {
+static INLINE size_t sdsavail(const sds s) {
     struct sdshdr *sh = (void*)(s-sizeof *sh);
     return sh->free;
 }


### PR DESCRIPTION
@antirez: Thank you for a great library! I realize that supporting Visual Studio is probably not your highest priority. However, with the C99 support added in Visual Studio 2013, all that is needed is this short macro, from http://en.wikipedia.org/wiki/Inline_function#Microsoft_Visual_C.2B.2B_specific.
