### PR TITLE
Implemented sdscmpstr

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,4 +9,4 @@ Version 2.0
 Version 1.0
 ===
 
-* Initial SDS stand alone verison.
+* Initial SDS stand alone version.

--- a/sds.c
+++ b/sds.c
@@ -1209,7 +1209,7 @@ int sdsTest(void) {
         sdsfree(x);
         x = sdsnew("aar");
         y = sdsnew("bar");
-        test_cond("sdscmp(bar,bar)", sdscmp(x,y) < 0)
+        test_cond("sdscmp(aar,bar)", sdscmp(x,y) < 0)
 
         sdsfree(y);
         sdsfree(x);

--- a/sds.h
+++ b/sds.h
@@ -240,6 +240,7 @@ void sdsrange(sds s, int start, int end);
 void sdsupdatelen(sds s);
 void sdsclear(sds s);
 int sdscmp(const sds s1, const sds s2);
+int sdscmpstr(const sds s1, const char *s2, size_t l2);
 sds *sdssplitlen(const char *s, int len, const char *sep, int seplen, int *count);
 void sdsfreesplitres(sds *tokens, int count);
 void sdstolower(sds s);


### PR DESCRIPTION
I wrote this function for a linked list with items that had binary string keys and if the item existed it would only update it's value and not the key thus avoiding another temporary sdsnewlen allocation for comparing keys