### PR TITLE
Fix check for s_malloc

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -89,9 +89,9 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
Line 91 makes a call to s_malloc (which is defined as malloc in sdsalloc.h) and assigns the return value to sh. The check for whether this call to s_malloc succeeded is not until Line 94. On Lines 92-93, if init is NULL, then an attempt to zero out the memory area pointed to by sh is made. If s_malloc fails (and thus returns NULL), memset will be called with a NULL address (because sh is NULL), resulting in a seg fault. This possible seg fault can be prevented by moving the check on Line 94 to Line 92, after the call to s_malloc.
