### PR TITLE
Potential null pointer access in sdsnewlen

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -92,9 +92,9 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
As referenced in issue #67 this fixes a null pointer access in `sdsnewlen`.
This is only posssible because `s_malloc` is actually just `malloc` instead of `zmalloc` like in redis.