### PR TITLE
README typo: usualy -> usual.

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ existing string the quoted string representation of the input string.
 sds sdscatrepr(sds s, const char *p, size_t len);
 ```
 
-The `scscatrepr` (where `repr` means *representation*) follows the usualy
+The `scscatrepr` (where `repr` means *representation*) follows the usual
 SDS string function rules accepting a char pointer and a length, so you can
 use it with SDS strings, normal C strings by using strlen() as `len` argument,
 or binary data. The following is an example usage:


### PR DESCRIPTION
The word "usual" and "usually" are legal, but "usualy" is not legal.
In addition, use  "usual" maybe better.
D:)

Signed-off-by: Bo Cai <charpty@gmail.com>