### PR TITLE
repair malloc fail bug

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -92,9 +92,9 @@ sds sdsnewlen(const void *init, size_t initlen) {
     unsigned char *fp; /* flags pointer. */
 
     sh = s_malloc(hdrlen+initlen+1);
+    if (sh == NULL) return NULL;
     if (!init)
         memset(sh, 0, hdrlen+initlen+1);
-    if (sh == NULL) return NULL;
     s = (char*)sh+hdrlen;
     fp = ((unsigned char*)s)-1;
     switch(type) {


### PR DESCRIPTION
I think check "if (sh == NULL) return NULL;" should be ahead, if not, core dump will happen.