### PR TITLE
Safety improvements.

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -35,6 +35,23 @@
 
 #define SDS_MAX_PREALLOC (1024*1024)
 
+/* Safety wrapper over GNU C attributes.
+ * Works for Clang as well. */
+#ifdef __GNUC__
+  #define _attr_(A) __attribute__((A))
+#else
+  #define _attr_(A)
+#endif
+
+/* Warns on unused return value. */
+#define _used_   _attr_(warn_unused_result)
+
+/* Packs a structure. */
+#define _packed_ _attr_(__packed__)
+
+/* Gurantees no aliasing for newly allocated data. */
+#define _malloc_ _attr_(malloc)
+
 #include <sys/types.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -43,29 +60,29 @@ typedef char *sds;
 
 /* Note: sdshdr5 is never used, we just access the flags byte directly.
  * However is here to document the layout of type 5 SDS strings. */
-struct __attribute__ ((__packed__)) sdshdr5 {
+struct _packed_ sdshdr5 {
     unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
     char buf[];
 };
-struct __attribute__ ((__packed__)) sdshdr8 {
+struct _packed_ sdshdr8 {
     uint8_t len; /* used */
     uint8_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
     char buf[];
 };
-struct __attribute__ ((__packed__)) sdshdr16 {
+struct _packed_ sdshdr16 {
     uint16_t len; /* used */
     uint16_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
     char buf[];
 };
-struct __attribute__ ((__packed__)) sdshdr32 {
+struct _packed_ sdshdr32 {
     uint32_t len; /* used */
     uint32_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
     char buf[];
 };
-struct __attribute__ ((__packed__)) sdshdr64 {
+struct _packed_ sdshdr64 {
     uint64_t len; /* used */
     uint64_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
@@ -214,56 +231,51 @@ static inline void sdssetalloc(sds s, size_t newlen) {
     }
 }
 
-sds sdsnewlen(const void *init, size_t initlen);
-sds sdsnew(const char *init);
-sds sdsempty(void);
-sds sdsdup(const sds s);
+_used_ _malloc_ sds sdsnewlen(const void *init, size_t initlen);
+_used_ _malloc_ sds sdsnew(const char *init);
+_used_ _malloc_ sds sdsempty(void);
+_used_ _malloc_ sds sdsdup(const sds s);
 void sdsfree(sds s);
-sds sdsgrowzero(sds s, size_t len);
-sds sdscatlen(sds s, const void *t, size_t len);
-sds sdscat(sds s, const char *t);
-sds sdscatsds(sds s, const sds t);
-sds sdscpylen(sds s, const char *t, size_t len);
-sds sdscpy(sds s, const char *t);
+_used_ sds sdsgrowzero(sds s, size_t len);
+_used_ sds sdscatlen(sds s, const void *t, size_t len);
+_used_ sds sdscat(sds s, const char *t);
+_used_ sds sdscatsds(sds s, const sds t);
+_used_ sds sdscpylen(sds s, const char *t, size_t len);
+_used_ sds sdscpy(sds s, const char *t);
 
-sds sdscatvprintf(sds s, const char *fmt, va_list ap);
-#ifdef __GNUC__
-sds sdscatprintf(sds s, const char *fmt, ...)
-    __attribute__((format(printf, 2, 3)));
-#else
-sds sdscatprintf(sds s, const char *fmt, ...);
-#endif
+_used_ sds sdscatvprintf(sds s, const char *fmt, va_list ap);
+_used_ sds sdscatprintf(sds s, const char *fmt, ...) _attr_(format(printf, 2, 3));
 
-sds sdscatfmt(sds s, char const *fmt, ...);
+_used_ sds sdscatfmt(sds s, char const *fmt, ...);
 sds sdstrim(sds s, const char *cset);
 void sdsrange(sds s, ssize_t start, ssize_t end);
 void sdsupdatelen(sds s);
 void sdsclear(sds s);
-int sdscmp(const sds s1, const sds s2);
-sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *count);
+_used_ int sdscmp(const sds s1, const sds s2);
+_used_ sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *count);
 void sdsfreesplitres(sds *tokens, int count);
 void sdstolower(sds s);
 void sdstoupper(sds s);
-sds sdsfromlonglong(long long value);
-sds sdscatrepr(sds s, const char *p, size_t len);
-sds *sdssplitargs(const char *line, int *argc);
-sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
-sds sdsjoin(char **argv, int argc, char *sep);
-sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
+_used_ sds sdsfromlonglong(long long value);
+_used_ sds sdscatrepr(sds s, const char *p, size_t len);
+_used_ sds *sdssplitargs(const char *line, int *argc);
+_used_ sds sdsmapchars(sds s, const char *from, const char *to, size_t setlen);
+_used_ sds sdsjoin(char **argv, int argc, char *sep);
+_used_ sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
 
 /* Low level functions exposed to the user API */
-sds sdsMakeRoomFor(sds s, size_t addlen);
+_used_ sds sdsMakeRoomFor(sds s, size_t addlen);
 void sdsIncrLen(sds s, ssize_t incr);
-sds sdsRemoveFreeSpace(sds s);
-size_t sdsAllocSize(sds s);
-void *sdsAllocPtr(sds s);
+_used_ sds sdsRemoveFreeSpace(sds s);
+_used_ size_t sdsAllocSize(sds s);
+_used_ void *sdsAllocPtr(sds s);
 
 /* Export the allocator used by SDS to the program using SDS.
  * Sometimes the program SDS is linked to, may use a different set of
  * allocators, but may want to allocate or free things that SDS will
  * respectively free or allocate. */
-void *sds_malloc(size_t size);
-void *sds_realloc(void *ptr, size_t size);
+_used_ _malloc_ void *sds_malloc(size_t size);
+_used_ _malloc_ void *sds_realloc(void *ptr, size_t size);
 void sds_free(void *ptr);
 
 #ifdef REDIS_TEST


### PR DESCRIPTION
This adds a couple of new features which don't change the existing code at all.

The first and foremost of which is to add a new macro named `_attr_` which is only active when GNU C is defined, which [should work for both GCC and Clang.](https://godbolt.org/g/groKXF)

Secondly, some macros are defined based on this:

`_used_` (`__attribute__((warn_unused_result))`) warns the programmer when they forget to use the return value of a function. This works nicely to help reduce the number of potential bugs caused by the necessity of having the sds as a return value without any form of warning.

`_packed_` (`__attribute__((__packed__))`) is basically just a wrapper for the packing attribute that was used previously.

`_malloc_` (`__attribute__((malloc))`) gurantees to the compiler that the pointer returned by a function is unique and will not be aliased, allowing for some potential optimizations. This should not be applied to realloc style functions.

TLDR: This improves the safety of the library and may make it slightly more portable and fast at runtime. I haven't done any benchmarking, but no breaking changes were made; all of the tests still pass.
If you decide not to merge this pr, I'd still suggest you look at doing this in your own style, because I think it would be nice to have `__attribute__((warn_unused_result))` on allocating and reallocating functions.