### PR TITLE
Change SDS_HDR_VAR macro to a properer definition.

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -80,8 +80,8 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 #define SDS_TYPE_64 4
 #define SDS_TYPE_MASK 7
 #define SDS_TYPE_BITS 3
-#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));
 #define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
+#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = SDS_HDR(T,s)
 #define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
 
 static inline size_t sdslen(const sds s) {


### PR DESCRIPTION
Avoid type conversion error in c++ and since we already have a SDS_HDR macro.
