### PR TITLE
Fixed empty tokens caused by the location of separator in sdssplitlen()

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -828,7 +828,7 @@ sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *c
         return tokens;
     }
     for (j = 0; j < (len-(seplen-1)); j++) {
-        /* make sure there is room for the next element or the final one */
+        /* make sure there is room for the next element and the final one */
         if (slots < elements+2) {
             sds *newtokens;
 

--- a/sds.c
+++ b/sds.c
@@ -828,7 +828,7 @@ sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *c
         return tokens;
     }
     for (j = 0; j < (len-(seplen-1)); j++) {
-        /* make sure there is room for the next element and the final one */
+        /* make sure there is room for the next element or the final one */
         if (slots < elements+2) {
             sds *newtokens;
 
@@ -839,17 +839,21 @@ sds *sdssplitlen(const char *s, ssize_t len, const char *sep, int seplen, int *c
         }
         /* search the separator */
         if ((seplen == 1 && *(s+j) == sep[0]) || (memcmp(s+j,sep,seplen) == 0)) {
-            tokens[elements] = sdsnewlen(s+start,j-start);
-            if (tokens[elements] == NULL) goto cleanup;
-            elements++;
+            if (j != 0) { /* make sure the separator is not at the beginning */
+                tokens[elements] = sdsnewlen(s+start,j-start);
+                if (tokens[elements] == NULL) goto cleanup;
+                elements++;
+            }
             start = j+seplen;
             j = j+seplen-1; /* skip the separator */
         }
     }
     /* Add the final element. We are sure there is room in the tokens array. */
-    tokens[elements] = sdsnewlen(s+start,len-start);
-    if (tokens[elements] == NULL) goto cleanup;
-    elements++;
+    if (len-start != 0) { /* make sure the string is not ended with the separator */
+       tokens[elements] = sdsnewlen(s+start,len-start);
+       if (tokens[elements] == NULL) goto cleanup;
+       elements++;
+    }
     *count = elements;
     return tokens;
 


### PR DESCRIPTION
The tokens will contain empty sds element when the separator is at the beginning or the end of the unsplit string