### PR TITLE
fix SDS_NOINIT declaration for gcc -fno-common

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -34,7 +34,7 @@
 #define __SDS_H
 
 #define SDS_MAX_PREALLOC (1024*1024)
-const char *SDS_NOINIT;
+extern const char *SDS_NOINIT;
 
 #include <sys/types.h>
 #include <stdarg.h>


### PR DESCRIPTION
SDS_NOINIT is currently declared in sds.h without extern, resulting in
multiple definitions across sds.h consumers.
With GCC 10, the default of -fcommon option will change to -fno-common,
resulting in an error.