### PR TITLE
Make sds.h compatible for C++

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -80,7 +80,7 @@ struct __attribute__ ((__packed__)) sdshdr64 {
 #define SDS_TYPE_64 4
 #define SDS_TYPE_MASK 7
 #define SDS_TYPE_BITS 3
-#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));
+#define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (struct sdshdr##T*)((s)-(sizeof(struct sdshdr##T)));
 #define SDS_HDR(T,s) ((struct sdshdr##T *)((s)-(sizeof(struct sdshdr##T))))
 #define SDS_TYPE_5_LEN(f) ((f)>>SDS_TYPE_BITS)
 


### PR DESCRIPTION
I know that sds is a library solely intended for C but I happened to include the header "sds.h" in a C++ application, I don't want to go into details why I needed to do this. However, when compiling the C++ application I get some of these errors:

```
sds.h:83:49: error: invalid conversion from ‘void*’ to ‘sdshdr8*’ [-fpermissive]
 #define SDS_HDR_VAR(T,s) struct sdshdr##T *sh = (void*)((s)-(sizeof(struct sdshdr##T)));                 
                                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
```
A minor change in the header would fix this issue. I don't think that it breaks anything, but I think you @antirez know best if it causes side-effects or not.

I've tested this change with in my Application and it works fine in C and C++ so far.

