### PR TITLE
docs: fix simple typo, termined -> terminated

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -78,7 +78,7 @@ static inline char sdsReqType(size_t string_size) {
  * If NULL is used for 'init' the string is initialized with zero bytes.
  * If SDS_NOINIT is used, the buffer is left uninitialized;
  *
- * The string is always null-termined (all the sds strings are, always) so
+ * The string is always null-terminated (all the sds strings are, always) so
  * even if you create an sds string with:
  *
  * mystring = sdsnewlen("abc",3);
@@ -434,7 +434,7 @@ sds sdscpylen(sds s, const char *t, size_t len) {
     return s;
 }
 
-/* Like sdscpylen() but 't' must be a null-termined string so that the length
+/* Like sdscpylen() but 't' must be a null-terminated string so that the length
  * of the string is obtained with strlen(). */
 sds sdscpy(sds s, const char *t) {
     return sdscpylen(s, t, strlen(t));


### PR DESCRIPTION
There is a small typo in sds.c.

Should read `terminated` rather than `termined`.

