### PR TITLE
Add note about sdsnewlen(0, ...) to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ There are many ways to create SDS strings:
   Note: `sdslen` return value is casted to `int` because it returns a `size_t`
 type. You can use the right `printf` specifier instead of casting.
 
+  Note: If the first argument to `sdsnewlen` is `0`, it will zero-initialize the
+string's memory. This way you can create an empty buffer of a certain length.
+
 * The `sdsempty()` function creates an empty zero-length string:
 
     ```c


### PR DESCRIPTION
It's convenient that `sdsnewlen` accepts `0` as a first argument, giving us a way to create an empty buffer of a given length. It would be nice to document this in the readme.

I don't know how the wording should be, but it felt lazy to not make a PR for such a small change. Feel free to close this PR and use whatever wording you like ;-)