### PR TITLE
Teach sdscatfmt to take %c conversion specifier.

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -626,6 +626,11 @@ sds sdscatfmt(sds s, char const *fmt, ...) {
             next = *(f+1);
             f++;
             switch(next) {
+            case 'c':
+                num = va_arg(ap,int);
+                s[i++] = num;
+                sdsinclen(s,1);
+                break;
             case 's':
             case 'S':
                 str = va_arg(ap,char*);


### PR DESCRIPTION
This adds the standard `%c` specifier to write an int as a char.