### PR TITLE
Add MSVC support.

### DIFF
--- a/sds.h
+++ b/sds.h
@@ -42,36 +42,47 @@ extern const char *SDS_NOINIT;
 
 typedef char *sds;
 
+#ifdef _MSC_VER
+__pragma(pack(push, 1))
+#define _SDS_PACKED
+#else
+#define _SDS_PACKED __attribute__ ((__packed__))
+#endif
+
 /* Note: sdshdr5 is never used, we just access the flags byte directly.
  * However is here to document the layout of type 5 SDS strings. */
-struct __attribute__ ((__packed__)) sdshdr5 {
+struct _SDS_PACKED sdshdr5 {
     unsigned char flags; /* 3 lsb of type, and 5 msb of string length */
     char buf[];
 };
-struct __attribute__ ((__packed__)) sdshdr8 {
+struct _SDS_PACKED sdshdr8 {
     uint8_t len; /* used */
     uint8_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
     char buf[];
 };
-struct __attribute__ ((__packed__)) sdshdr16 {
+struct _SDS_PACKED sdshdr16 {
     uint16_t len; /* used */
     uint16_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
     char buf[];
 };
-struct __attribute__ ((__packed__)) sdshdr32 {
+struct _SDS_PACKED sdshdr32 {
     uint32_t len; /* used */
     uint32_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
     char buf[];
 };
-struct __attribute__ ((__packed__)) sdshdr64 {
+struct _SDS_PACKED sdshdr64 {
     uint64_t len; /* used */
     uint64_t alloc; /* excluding the header and null terminator */
     unsigned char flags; /* 3 lsb of type, 5 unused bits */
     char buf[];
 };
+
+#ifdef _MSC_VER
+__pragma(pack(pop))
+#endif
 
 #define SDS_TYPE_5  0
 #define SDS_TYPE_8  1


### PR DESCRIPTION
Some poor souls like me need to support cross platform builds.
This patch adds support for MSVC and leaves everything else intact.

MSVC does not support `__attribute__ ((__packed__))`.
Add support via `__pragma(pack(push, 1))` when compiling with MSVC.
