### PR TITLE
fix missing dependecies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 all: sds-test
 
-sds-test: sds.c sds.h testhelp.h
+sds-test: sds.c sds.h testhelp.h sdsalloc.h
 	$(CC) -o sds-test sds.c -Wall -std=c99 -pedantic -O2 -DSDS_TEST_MAIN
 	@echo ">>> Type ./sds-test to run the sds.c unit tests."
 
-clean:
+clean: 
 	rm -f sds-test


### PR DESCRIPTION
This PR fixes an issue in the Makefile. Specifically, previously, any modifications of files like sdsalloc.h would not trigger a rebuild of sds-test. The PR fixes this by including them as additional dependencies.